### PR TITLE
fix types

### DIFF
--- a/src/components/types.d.ts
+++ b/src/components/types.d.ts
@@ -3,9 +3,15 @@ import type {
   ImageStyle,
   StyleProp,
   ViewStyle,
+  ImageProps,
 } from 'react-native';
 
-export type ImageZoomProps = {
+export type ImageZoomProps = Omit<ImageProps, 'source'> && {
+  /**
+   * The image source (either a remote URL or a local file resource).
+   * @default undefined
+   */
+  source?: ImageSourcePropType;
   /**
    * Uri of the image.
    * @default ''
@@ -101,3 +107,5 @@ export type ImageZoomProps = {
    */
   renderLoader?: Function;
 };
+
+export declare class ImageZoom extends React.Component<ImageZoomProps> {}


### PR DESCRIPTION
- fix typescript error  `Module '"@likashefqet/react-native-image-zoom"' has not exported member 'ImageZoom'`.
- make it possible to use react native image props in typescript.

## Motivation

We have typechecking errors due to lake of declarations. Also, we need to make `source` prop optional to be able to use the `uri` prop.
