### PR TITLE
Add resetZoomOnGestureEnd prop to allow it to be set to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,21 @@ Basics:
 <ImageZoom uri={imageUri} />
 ```
 
+If you want to reset the zoom manually:
+```javascript
+const imageZoomRef = useRef()
+<ImageZoom ref={imageZoomRef} uri={imageUri} resetZoomOnGestureEnd={false} />
+
+Then you can call the resetZoom function manually:
+imageZoomRef.current.resetZoom()
+```
+
 ## Properties
 All `React Native Image Props` &
 
 | Property               | Type     | Default             | Description                                                                                |
 | ---------------------- | -------- | ------------------- | ------------------------------------------------------------------------------------------ |
+| ref | MutableRefObject<typeof ImageZoom> | undefined | A React reference to the ImageZoom component. |
 | uri                    | String   | `''` (empty string) | Image uri. Can be overridden by source prop.                                               |
 | minScale               | Number   | `1`                 | The minimum allowed zoom scale.                                                            |
 | maxScale               | Number   | `5`                 | The maximum allowed zoom scale.                                                            |
@@ -63,6 +73,7 @@ All `React Native Image Props` &
 | onPinchEnd             | Function | `undefined`         | Callback to trigger when the image pinching ends.                                          |
 | onPanStart             | Function | `undefined`         | Callback to trigger when the image panning starts.                                         |
 | onPanEnd               | Function | `undefined`         | Callback to trigger when the image panning ends.                                           |
+| resetZoomOnGestureEnd | boolean | true | Reset zoom and snap back to initial position on gesture end. |
 
 ## Changelog
 

--- a/src/components/types.d.ts
+++ b/src/components/types.d.ts
@@ -106,6 +106,10 @@ export type ImageZoomProps = Omit<ImageProps, 'source'> && {
    * Render custom loader component.
    */
   renderLoader?: Function;
+    /**
+   * Reset zoom and snap back to initial position on gesture end.
+   */
+  resetZoomOnGestureEnd?: boolean;
 };
 
 export declare class ImageZoom extends React.Component<ImageZoomProps> {}


### PR DESCRIPTION
## Motivation

The users of my application would like for the panning and pinching to not reset back. Adding this flag will allow this use case to be easily achieved. By default, the prop will be true as to not change current default functionality.