### PR TITLE
fix: fix reanimated dependecy array error on web

### DIFF
--- a/src/hooks/useGestures.ts
+++ b/src/hooks/useGestures.ts
@@ -151,15 +151,18 @@ export const useGestures = ({
       runOnJS(onPinchEnded)(...args);
     });
 
-  const animatedStyle = useAnimatedStyle(() => ({
-    transform: [
-      { translateX: translate.x.value },
-      { translateY: translate.y.value },
-      { translateX: focal.x.value },
-      { translateY: focal.y.value },
-      { scale: scale.value },
-    ],
-  }));
+  const animatedStyle = useAnimatedStyle(
+    () => ({
+      transform: [
+        { translateX: translate.x.value },
+        { translateY: translate.y.value },
+        { translateX: focal.x.value },
+        { translateY: focal.y.value },
+        { scale: scale.value },
+      ],
+    }),
+    [scale]
+  );
 
   const gestures = Gesture.Simultaneous(pinchGesture, panGesture);
 


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

This pull request addresses an error occurring when utilizing the react-native-image-zoom component on the web platform. The issue was caused by the lack of necessary dependency array on the hook `useAnimatedStyle`.

https://docs.swmansion.com/react-native-reanimated/docs/guides/web-support/#web-without-the-babel-plugin

