### PR TITLE
Add final scale value to onPinchEnd callback

### DIFF
--- a/src/hooks/useGestures.ts
+++ b/src/hooks/useGestures.ts
@@ -164,6 +164,7 @@ export const useGestures = ({
 
   const onPinchEnded: OnPinchEndCallback = (...args) => {
     isPinching.current = false;
+    args.push(scale.value);
     onPinchEnd?.(...args);
     onInteractionEnded();
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,8 @@ export type OnPinchStartCallback = (
 
 export type OnPinchEndCallback = (
   event: GestureStateChangeEvent<PinchGestureHandlerEventPayload>,
-  success: boolean
+  success: boolean,
+  scale: number
 ) => void;
 
 export type OnPanStartCallback = (


### PR DESCRIPTION
## Motivation

I have ImageZoom elements within an existing carousel, and I need to disable the carousel's gesture handlers when the image is zoomed in. There does not seem to be an easy way, currently, to get the current scale for the image. With the existing callback, if you use `event.scale`, it may return a value less than 1 because it returns the result of the gesture and not what the clamped value is.

My guess at a fix (testing locally, I have another branch locally anyway to use Expo Image) is to add the scale as an argument to the `onPinchEnd` callback with the actual _rendered_ scale.

(Also v3 could not have come at a better time, love it)