### PR TITLE
New finalScalePosition Param

### DIFF
--- a/src/hooks/useGestures.ts
+++ b/src/hooks/useGestures.ts
@@ -371,7 +371,12 @@ export const useGestures = ({
         (center.y - initialFocal.y.value) * (scale.value - savedScale.value);
     })
     .onEnd((...args) => {
-      runOnJS(onPinchEnded)(...args);
+      const argsWithScale = {
+        ...args[0],
+        finalScalePosition: scale.value
+      };
+
+      runOnJS(onPinchEnded)(argsWithScale);
     });
 
   const doubleTapGesture = Gesture.Tap()


### PR DESCRIPTION
When we use the onPinchEnd event as so:

onPinchEnd={(e) => console.log('onPinchEnd', e)}

It returns only the scale change, not the new scale. I propose to include another parameter which returns the current scale as well.

This is super useful for matching other UI elements that may need to move in time with the image being scaled.

I've proposed the name 'finalScalePosition'.

(https://github.com/likashefqet/react-native-image-zoom/issues/83)
